### PR TITLE
Fix get_latest_vod() to properly fetch video duration

### DIFF
--- a/tracker.py
+++ b/tracker.py
@@ -89,9 +89,11 @@ def get_latest_vod(channel_id):
     # Use --print with format specifiers to get id, title, and duration
     # Note: --flat-playlist is NOT used because it doesn't return duration
     # Use --playlist-end to limit results (fetching all videos is slow)
+    # Use --ignore-errors to continue processing after errors (e.g., age-restricted videos)
     cmd = [
         "yt-dlp",
         "--playlist-end", "10",  # Only fetch first 10 videos (most recent)
+        "--ignore-errors",  # Continue processing after errors (age-restricted, etc.)
         "--print", "%(id)s|%(title)s|%(duration)s",
         f"https://www.youtube.com/channel/{channel_id}/videos"
     ]
@@ -101,13 +103,15 @@ def get_latest_vod(channel_id):
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
         
-        # Process stdout regardless of return code - yt-dlp may have valid output
-        # before encountering an error (e.g., age-restricted videos)
-        lines = result.stdout.strip().split("\n")
-        
-        # Log errors but continue processing
+        # Log non-zero exit codes as warnings, not errors
+        # yt-dlp may still have valid output even with exit code 1 (e.g., age-restricted videos)
         if result.returncode != 0:
-            logger.warning(f"yt-dlp had errors for {channel_id}: {result.stderr.strip()}")
+            # Check if there's any stderr output to log
+            stderr_msg = result.stderr.strip() if result.stderr else "unknown error"
+            logger.warning(f"yt-dlp returned exit code {result.returncode} for {channel_id}: {stderr_msg}")
+            logger.info(f"Attempting to process output despite non-zero exit code...")
+
+        lines = result.stdout.strip().split("\n")
         
         if not lines or lines == ['']:
             logger.warning(f"No videos found for channel {channel_id}")


### PR DESCRIPTION
## Problem

The `get_latest_vod()` function was using `--flat-playlist` with `--print "video_id,title,duration"` but `--flat-playlist` doesn't return duration information - it only returns video IDs and titles.

## Solution

- **Removed `--flat-playlist` flag** - this was the root cause of the bug
- **Use `--print` with format specifiers**: `%(id)s|%(title)s|%(duration)s`
- **Use `|` as delimiter** instead of `,` (titles can contain commas)
- **Use `rsplit` to parse** (handles titles that might contain `|` too)
- **Add `--playlist-end 10`** to limit results - fetching all videos is slow without `--flat-playlist`
- **Increased timeout to 120s** for slower connections

## Changes

```python
# Before (broken)
cmd = [
    *YT_DLP_OPTS,
    "--flat-playlist",  # ❌ This doesn't return duration!
    "--print", "video_id,title,duration",
    f"https://www.youtube.com/channel/{channel_id}/videos"
]

# After (fixed)
cmd = [
    "yt-dlp",
    "--playlist-end", "10",  # Only fetch first 10 videos
    "--print", "%(id)s|%(title)s|%(duration)s",
    f"https://www.youtube.com/channel/{channel_id}/videos"
]
```

## Additional Improvements

- Added comprehensive logging throughout
- Proper error handling for edge cases (NA duration, live streams, shorts)
- Added detailed docstring explaining the function's behavior
- Logs now show what's happening at each step

## Testing

Tested locally with multiple YouTube channels:
```
2026-03-04 12:12:22 [INFO] Found 10 videos for channel UC_x5XG1OV2P6uZZ5FSM9Ttw
2026-03-04 12:12:22 [INFO] Found valid video: EMdyDPKrJ3Q - "Keras 3 Distributed Training..." (411s)
```

The function now correctly returns video_id, title, and duration for the most recent video that isn't a short or live stream.