### PR TITLE
Add .env file support with python-dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# OpenAI
+OPENAI_API_KEY=your_key_here
+
+# Anthropic
+ANTHROPIC_API_KEY=your_key_here
+
+# MiniMax
+MINIMAX_API_KEY=your_key_here
+MINIMAX_GROUP_ID=your_group_id_here
+
+# Optional: Local Ollama
+OLLAMA_HOST=http://localhost:11434

--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ Add channel IDs to `channels.json`:
 }
 ```
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and configure your API keys:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your actual credentials:
+
+```bash
+# Required for OpenAI provider (default)
+OPENAI_API_KEY=sk-your-key-here
+
+# Required for Anthropic provider
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Required for MiniMax provider
+MINIMAX_API_KEY=your-key-here
+MINIMAX_GROUP_ID=your-group-id-here
+
+# Optional: For local Ollama
+OLLAMA_HOST=http://localhost:11434
+```
+
+**Important:** Never commit `.env` to version control. It's already in `.gitignore`.
+
 ## Usage
 
 ### Basic VOD Tracking

--- a/clip_finder.py
+++ b/clip_finder.py
@@ -15,6 +15,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+# Load environment variables from .env file
+from dotenv import load_dotenv
+load_dotenv()
+
 # Config - Use environment variables with fallbacks
 WORKSPACE = Path(os.environ.get("VOD_WORKSPACE", Path(__file__).parent))
 DATA_DIR = WORKSPACE / "data"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core dependencies
 yt-dlp>=2024.1.0
+python-dotenv>=1.0.0
 
 # Best bits feature (optional - for transcription)
 # Uncomment if using local Whisper:

--- a/tracker.py
+++ b/tracker.py
@@ -13,6 +13,10 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+# Load environment variables from .env file
+from dotenv import load_dotenv
+load_dotenv()
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
## Summary

- Added `python-dotenv` as a dependency for loading environment variables from `.env` files
- Updated `clip_finder.py` and `tracker.py` to load `.env` files at startup
- Created `.env.example` with all required environment variables documented
- Updated README with `.env` setup instructions

## Changes

### requirements.txt
- Added `python-dotenv>=1.0.0`

### clip_finder.py & tracker.py
- Added `from dotenv import load_dotenv` import
- Called `load_dotenv()` at the start of each script to load `.env` files

### .env.example (new file)
Template with all required environment variables:
- `OPENAI_API_KEY`
- `ANTHROPIC_API_KEY`
- `MINIMAX_API_KEY` and `MINIMAX_GROUP_ID`
- `OLLAMA_HOST` (optional)

### README.md
- Added new "Environment Variables" section under Configuration
- Instructions for copying `.env.example` to `.env`
- Warning about never committing `.env` to version control

## Security

`.env` was already in `.gitignore`, so existing behavior is preserved. This change just makes it easier for users to configure their API keys without manually setting environment variables.